### PR TITLE
Add block without 1 confirming block txs to mempool

### DIFF
--- a/bchain/coins/dcr/decredparser.go
+++ b/bchain/coins/dcr/decredparser.go
@@ -162,6 +162,9 @@ func (p *DecredParser) ParseTxFromJson(jsonTx json.RawMessage) (*bchain.Tx, erro
 		Time:          getTxResult.Result.Time,
 		Blocktime:     getTxResult.Result.Blocktime,
 	}
+
+	tx.CoinSpecificData = getTxResult.Result.TxExtraInfo
+
 	return tx, nil
 }
 

--- a/bchain/coins/dcr/decredparser_test.go
+++ b/bchain/coins/dcr/decredparser_test.go
@@ -127,7 +127,6 @@ func TestGetAddrDescFromAddress(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	parser := NewDecredParser(GetChainParams("testnet3"), &btc.Configuration{})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -172,7 +171,6 @@ func TestGetAddrDescFromVout(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	parser := NewDecredParser(GetChainParams("testnet3"), &btc.Configuration{})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -221,8 +219,6 @@ func TestGetAddressesFromAddrDesc(t *testing.T) {
 			wantErr: false,
 		},
 	}
-
-	parser := NewDecredParser(GetChainParams("testnet3"), &btc.Configuration{})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/configs/coins/decred.json
+++ b/configs/coins/decred.json
@@ -55,7 +55,7 @@
         "subversion":"/Decred dcrd:1.4.0",
         "mempool_workers": 8,
         "mempool_sub_workers": 2,
-        "block_addresses_to_keep": 300,
+        "block_addresses_to_keep": 30,
         "xpub_magic": 49990397,
         "slip44": 3,
         "additional_params": {}

--- a/configs/coins/decred_testnet.json
+++ b/configs/coins/decred_testnet.json
@@ -55,7 +55,7 @@
         "subversion":"/Decred dcrd:1.4.0",
         "mempool_workers": 8,
         "mempool_sub_workers": 2,
-        "block_addresses_to_keep": 300,
+        "block_addresses_to_keep": 30,
         "xpub_magic": 49990397,
         "slip44": 3,
         "additional_params": {}


### PR DESCRIPTION
Adds the decred's chain best block without one confirming block to mempool data.

Even though decred's reorg depth is 6 block, I set the blockbook to be 30 blocks just be on the safe side by updating `"block_addresses_to_keep"` value.